### PR TITLE
Feature: Add service monitor option for automatic scrape configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ To override the default you can either :
 | secret.existing.secretName           | The name of an existing secret containing the Pihole credentials                            | my-pi-hole-secret |
 | secret.existing.piHoleCredentialType | The type of piHole credential in the secret, either 'PIHOLE_API_TOKEN' or 'PIHOLE_PASSWORD' |  PIHOLE_API_TOKEN |
 | secret.existing.secretKey            | The key within the secret containing the piHole api token or password                       |  PIHOLE_API_TOKEN |
+| serviceMonitor.enable                | Deploys a (Prometheus) ServiceMonitor resource for scraping autoconfiguration               |             false |
+

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
       protocol: TCP
-      name: exporter-port
+      name: {{ .Values.service.portName }}
   selector:
     app.kubernetes.io/name: {{ include "pihole-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "pihole-exporter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.server.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "pihole-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  endpoints:
+    - port: {{ .Values.service.portName }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "pihole-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -56,9 +56,9 @@ secret:
     # The key within the secret containing the piHole api token or password
     secretKey: PIHOLE_API_TOKEN
 
-
+# Configuration for the deployment of a 'ServiceMonitor' resource for autoconfiguration
 serviceMonitor:
-  # True - deploy a 'ServiceMonitor' resource, requires the kube-prometheus CRDs to be deployed beforehand
+  # true - deploy a 'ServiceMonitor' resource, requires the kube-prometheus CRDs to be deployed beforehand
   enabled: false
   namespace: ""
   interval: "60s"

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 9617 #DefaultImagePort-CanBeChangedBelow
+  portName: exporter-port
 
 ingress:
   enabled: false
@@ -54,6 +55,16 @@ secret:
     piHoleCredentialType: PIHOLE_API_TOKEN
     # The key within the secret containing the piHole api token or password
     secretKey: PIHOLE_API_TOKEN
+
+
+serviceMonitor:
+  # True - deploy a 'ServiceMonitor' resource, requires the kube-prometheus CRDs to be deployed beforehand
+  enabled: false
+  namespace: ""
+  interval: "60s"
+  scrapeTimeout: "30s"
+  relabelings: ""
+  metricRelabelings: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR adds the option for the creation of a Prometheus 'ServiceMonitor' resource to allow for automatic scrap configuration.

This PR also addresses the ability to easily integrate with the Prometheus operator or the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) as mentioned in #6.